### PR TITLE
fix: publiccode.yml validation errors

### DIFF
--- a/.github/workflows/publiccodeyml-check.yml
+++ b/.github/workflows/publiccodeyml-check.yml
@@ -1,0 +1,27 @@
+name: Validate publiccode.yml
+
+on:
+  push:
+    paths:
+      - "publiccode.yml"
+      - ".github/workflows/publiccodeyml-check.yml"
+  pull_request:
+    paths:
+      - "publiccode.yml"
+      - ".github/workflows/publiccodeyml-check.yml"
+
+permissions: {}
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    name: publiccode.yml validation
+    steps:
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+
+      - uses: italia/publiccode-parser-action@21086c73ec0563e14c6748787efa1b34b025ad8c # v1
+        with:
+          publiccode: "publiccode.yml"
+          no-network: true

--- a/publiccode.yml
+++ b/publiccode.yml
@@ -1,8 +1,8 @@
-# This repository adheres to the publiccode.yml standard by including this 
+# This repository adheres to the publiccode.yml standard by including this
 # metadata file that makes public software easily discoverable.
-# More info at https://github.com/italia/publiccode.yml
+# More info at https://github.com/publiccodeyml/publiccode.yml
 
-publiccodeYmlVersion: '0.2'
+publiccodeYmlVersion: '0'
 categories:
   - identity-management
 dependsOn:
@@ -22,29 +22,28 @@ description:
       - Saml2 proxy to SPID Saml
       - compliant to spid-saml-check validations
       - 'Customizable with additional backends, frontends and microservices'
-    genericName: web application
     longDescription: |
-      Satosa-Saml2 Spid is an intermediary between many SAML2 Service 
-      Providers and many SAML2 Identity Providers. Specifically it allows 
-      traditional Saml2 Service Providers to communicate with 
-      Spid Identity Providers adapting Metadata and AuthnRequest 
+      Satosa-Saml2 Spid is an intermediary between many SAML2 Service
+      Providers and many SAML2 Identity Providers. Specifically it allows
+      traditional Saml2 Service Providers to communicate with
+      Spid Identity Providers adapting Metadata and AuthnRequest
       operations to the Spid technical requirements.
-      This solution allows us to adopt multiple proxy frontends and backends to adapt and allows to 
+      This solution allows us to adopt multiple proxy frontends and backends to adapt and allows to
       communicate systems that, due to protocol or specific limitations, traditionally could not interact each other.
-      
+
       Short glossary:
-      
+
       - Frontend, interface of the proxy that is configured as a SAML2 Identity Provider
       - Backend, interface of the proxy that is configured as a SAML2 Service Provider
       - TargetRouting, a SATOSA microservice for selecting the output backend to reach the endpoint (IdP) selected by the user
       - Discovery Service, interface that allows users to select the authentication endpoint
 
-      
+
     screenshots:
       - |-
         https://github.com/UniversitaDellaCalabria/Satosa-Saml2Spid/blob/master/gallery/spid_proxy.png
       - |-
-        https://github.com/UniversitaDellaCalabria/Satosa-Saml2Spid/blob/master/gallery/disco.png
+        https://github.com/UniversitaDellaCalabria/Satosa-Saml2Spid/blob/master/gallery/disco_page.png
       - |-
         https://github.com/UniversitaDellaCalabria/Satosa-Saml2Spid/blob/master/gallery/error_page.png
     shortDescription: A proxy that allows legacy Saml2 service providers to communicate with Spid Identity Providers
@@ -52,24 +51,8 @@ developmentStatus: stable
 intendedAudience:
   scope:
     - infrastructures
-it:
-  conforme:
-    gdpr: true
-    lineeGuidaDesign: false
-    misureMinimeSicurezza: true
-    modelloInteroperabilita: false
-  countryExtensionVersion: '0.2'
-  piattaforme:
-    anpr: false
-    cie: false
-    pagopa: false
-    spid: true
-  riuso:
-    codiceIPA: unical
 landingURL: 'https://github.com/UniversitaDellaCalabria/Satosa-Saml2Spid'
 legal:
-  authorsFile: |-
-    https://raw.githubusercontent.com/UniversitaDellaCalabria/Satosa-Saml2Spid/master/AUTHORS
   license: Apache-2.0
   mainCopyrightOwner: Università della Calabria
 localisation:
@@ -96,4 +79,3 @@ usedBy:
   - Università della Calabria - https://www.unical.it
   - Università del Piemonte Orientale - https://www.uniupo.it
   - Istituto Superiore per la Protezione e la Ricerca Ambientale - https://www.isprabiente.gov.it
-


### PR DESCRIPTION
The publiccode.yml had a broken screenshot URL, an outdated `publiccodeYmlVersion`, and a few deprecated fields.